### PR TITLE
Downgrade to python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM python:3.11-rc-bullseye
+FROM python:3.10.2-alpine3.15
 
 WORKDIR /usr/src/app
 
 COPY . .
 
-RUN pip install -r requirements.txt
+RUN python -m pip install --upgrade pip
+RUN python -m pip install -r requirements.txt
 
 EXPOSE 5000
 CMD ["python", "-m", "flask", "run", "--host=0.0.0.0"]


### PR DESCRIPTION
Since Python 3.11 is not a stable version yet and will have some issues when installing flask-SQLalchemy, thus, I downgrade it to 3.10.

Files being changed in this PR:
- Dockerfile